### PR TITLE
log with stacktrace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/shirakiya/my-nature-remo
 go 1.19
 
 require github.com/mackerelio/mackerel-client-go v0.24.0
+
+require github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/mackerelio/mackerel-client-go v0.24.0 h1:Y9FeTgrQlDdtLU7FtMM6hd5mL5T4TvGCVUY0LH+bceQ=
 github.com/mackerelio/mackerel-client-go v0.24.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Without a stack trace, it is not at all clear where the error occurred, so the stack trace is output to the log.

Ref.

> go run main.go
2023/02/06 05:52:02 start
2023/02/06 05:52:02 invalid character '<' looking for beginning of value
exit status 1
make: *** [Makefile:7: run] Error 1
Error: Process completed with exit code 2.

https://github.com/shirakiya/my-nature-remo/actions/runs/4100793592/jobs/7071942788