### PR TITLE
Refine Docker Compose configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   go:
     build:
@@ -8,11 +7,10 @@ services:
     container_name: my-nature-remo-go
     working_dir: /go/src
     volumes:
-      - .:/go/src/
+      - .:/go/src
     environment:
-      - RUN_CONTEXT=
-      - NATURE_ACCESS_TOKEN
-      - MACKEREL_API_KEY
-      - MACKEREL_SERVICE_NAME=my-nature-remo
+      RUN_CONTEXT: ""
+      NATURE_ACCESS_TOKEN:
+      MACKEREL_API_KEY:
+      MACKEREL_SERVICE_NAME: ${MACKEREL_SERVICE_NAME:-my-nature-remo}
     command: go run main.go
-


### PR DESCRIPTION
## Why

Compose V2 の現行仕様に合わせ、構成ファイルの警告を解消して保守しやすくする。

## What

- Compose ファイルを標準の `compose.yaml` へ移行する。
- 廃止済みの `version` を削除し、環境変数と bind mount の記法を整理する。