### PR TITLE
chore: align golangci-lint version between Dockerfile and CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,19 +3,7 @@ name: Go
 on: push
 
 jobs:
-  fmt:
-    runs-on: ubuntu-latest
-    env:
-      RUN_CONTEXT:
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: 1.26.5
-      - name: go fmt
-        run: make fmt
-
-  golangci:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,12 +21,12 @@ linters:
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
   settings:
     goimports:
       local-prefixes:
-        - github.com/graffer-inc/go-commons
+        - github.com/shirakiya/my-nature-remo
 
 issues:
   max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.26.5
 
 WORKDIR /go/src
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-  sh -s -- -b $(go env GOPATH)/bin v2.5.0
+# renovate: datasource=github-releases depName=golangci/golangci-lint
+ARG GOLANGCI_LINT_VERSION=v2.12.2
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
 
 COPY go.mod .
 COPY go.sum .

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run:
 	$(RUN_CONTEXT) go run main.go
 
 fmt:
-	$(RUN_CONTEXT) go fmt ./...
+	$(RUN_CONTEXT) golangci-lint fmt
 
 lint:
 	$(RUN_CONTEXT) golangci-lint run

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,21 @@
   "addLabels": ["renovate"],
   "postUpdateOptions": ["gomodTidy"],
   "prHourlyLimit": 0,
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": [
+        "(_VERSION)? ?(: |= |:= )(?<currentValue>.+) +# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.+)\\n",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.+)\\n(ARG|ENV) .+_VERSION( |: |=)(?<currentValue>.+)"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["golangci/golangci-lint"],
+      "groupName": "golangci-lint"
+    }
+  ]
 }


### PR DESCRIPTION
## Why
Dockerfileのgolangci-lintバージョンがハードコードされておりCIのバージョンと乖離していたため、Renovateで追従できず手動更新に頼っていた。

## What

- Dockerfileのgolangci-lintバージョンをCIと同じv2.12.2に統一
- Dockerfile内のバージョンをRenovateのカスタムマネージャーで追跡できるようアノテーションを付与し、CI側のgolangci-lint-actionと同じdepNameでグループ化
- fmtをgolangci-lintに一本化
  - Makefileのfmtターゲットをgolangci-lint fmtに切り替え
  - .golangci.ymlのformattersをgofmtからgofumptに変更
  - CIのfmtジョブを廃止し、lintジョブ（golangci-lint run）にフォーマットチェックを一本化