### PR TITLE
ci: use go-version-file instead of go-version in setup-go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.26.5
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.26.5
+          go-version-file: go.mod
       - run: make run


### PR DESCRIPTION
## Why

setup-goでGoのバージョンを直接指定していたため、go.modのtoolchainディレクティブとバージョンが乖離する可能性があった。

## What

- setup-goの `go-version` を `go-version-file: go.mod` に変更し、go.modを唯一のバージョン指定元とした