### PR TITLE
Cache Go dependencies in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache-dependency-path: go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache-dependency-path: go.sum
       - run: make run


### PR DESCRIPTION
## Why

Ensure GitHub Actions invalidates the Go module cache whenever dependency checksums change.
ref. https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

## What

Configure both Go setup steps to use go.sum as the cache dependency path.